### PR TITLE
Add corneish_zen.conf file for setup script

### DIFF
--- a/app/boards/arm/corneish_zen/corneish_zen.conf
+++ b/app/boards/arm/corneish_zen/corneish_zen.conf
@@ -1,0 +1,5 @@
+# Go to sleep after one hour (1*60*60*1000ms)
+CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=3600000
+
+# Turn on logging, and set ZMK logging to debug output
+# CONFIG_ZMK_USB_LOGGING=y


### PR DESCRIPTION
Add the `.conf` file from the [official config repo](https://github.com/LOWPROKB/zmk-config-zen-2/blob/main/config/corneish_zen.conf) so that the ZMK setup script can copy it to the user config folder and the produced repo can match the official config repo.