### PR TITLE
improve partial refresh of e-ink display

### DIFF
--- a/app/drivers/display/il0323.c
+++ b/app/drivers/display/il0323.c
@@ -144,7 +144,7 @@ static int il0323_write(const struct device *dev, const uint16_t x, const uint16
     ptl[IL0323_PTL_HRED_IDX] = x_end_idx;
     ptl[IL0323_PTL_VRST_IDX] = y;
     ptl[IL0323_PTL_VRED_IDX] = y_end_idx;
-    ptl[sizeof(ptl) - 1] = IL0323_PTL_PT_SCAN;
+    ptl[sizeof(ptl) - 1] = 0; // 0 instead of IL0323_PTL_PT_SCAN limits fading outside of Window
     LOG_HEXDUMP_DBG(ptl, sizeof(ptl), "ptl");
 
     il0323_busy_wait(driver);


### PR DESCRIPTION
When parts of the e-ink display are refreshed, areas outside of the partial window suffer quite a bit. Not setting the PTL_SCAN bit of the PTL command for configuring the window, meaning "Gates scan only inside of the partial window" improves the behavior on my R3 Zen.

Of course I don't know what I am doing and why this is not the "default" (according to docs at https://github.com/CursedHardware/epd-driver-ic/blob/master/IL0323.pdf, p. 26).