### PR TITLE
Update upload-artifact to v4 in build-user-config.yml

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -117,7 +117,7 @@ jobs:
           fi
 
       - name: Archive (${{ env.display_name }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.archive_name }}
           path: build/artifacts


### PR DESCRIPTION
actions/upload-artifactv3 is deprecated and this is breaking firmware builds.

Replace with the supported v4 call.